### PR TITLE
Update NFT rotation timing to 5 seconds

### DIFF
--- a/new_nft_display.star
+++ b/new_nft_display.star
@@ -31,7 +31,7 @@ def main():
         )
     
     current_time = time.now().unix
-    nft_index = int(current_time / 5) % len(nfts)
+    nft_index = int(current_time / 5) % len(nfts)  # Changed to 5 second rotation
     current_nft = nfts[nft_index]
     
     image_url = get_image_url(current_nft)

--- a/update.sh
+++ b/update.sh
@@ -4,5 +4,5 @@ while true; do
     echo "Updating Tidbyt display..."
     pixlet render new_nft_display.star
     pixlet push biennially-optimum-prolific-vizcacha-f18 new_nft_display.webp --api-token eyJhbGciOiJFUzI1NiIsImtpZCI6IjY1YzFhMmUzNzJjZjljMTQ1MTQyNzk5ODZhMzYyNmQ1Y2QzNTI0N2IiLCJ0eXAiOiJKV1QifQ.eyJhdWQiOiJodHRwczovL2FwaS50aWRieXQuY29tIiwiZXhwIjozMzExODUwMzY0LCJpYXQiOjE3MzUwNTAzNjQsImlzcyI6Imh0dHBzOi8vYXBpLnRpZGJ5dC5jb20iLCJzdWIiOiJQRXdoZ3UxQ09FV2theEpveWlFR3h5UnAxcFkyIiwic2NvcGUiOiJkZXZpY2UiLCJkZXZpY2UiOiJiaWVubmlhbGx5LW9wdGltdW0tcHJvbGlmaWMtdml6Y2FjaGEtZjE4In0.hcv3rfbsu8TGi7m1SV0TUAXurLJ34brmUqFq-BVm2SqDCmLj0x3es64epOOm4uM-YifzZspKBJOweUH5LBwj8Q
-    sleep 10  # Wait 10 seconds before next update
+    sleep 5  # Changed to 5 second refresh
 done


### PR DESCRIPTION
This PR changes the NFT rotation and refresh intervals from 10 seconds to 5 seconds for a more dynamic display experience.

Changes:
- Modified `new_nft_display.star` to rotate NFTs every 5 seconds
- Updated `update.sh` refresh interval to 5 seconds to match the rotation speed

These changes will make the NFT display more dynamic while maintaining stability.